### PR TITLE
Changed the container width to `auto` to make life simpler

### DIFF
--- a/sass/ustyle/basics/_grid.sass
+++ b/sass/ustyle/basics/_grid.sass
@@ -1,7 +1,6 @@
 %container,
 .us-container
   +pie-clearfix
-  width: 100%
   margin-left: auto
   margin-right: auto
   position: relative


### PR DESCRIPTION
I've removed the 100% width from %container and .us-container. The default `auto` width is more flexible and we don't have to set `box-sizing: border-box`.
