### PR TITLE
Added "font-weight: normal" to the heading font extensions

### DIFF
--- a/sass/ustyle/basics/_fonts.sass
+++ b/sass/ustyle/basics/_fonts.sass
@@ -1,8 +1,11 @@
 %heading-font-bold
-  font-family: $heading-font-bold
+  font:
+    family: $heading-font-bold
+    weight: normal
 
 %heading-font-regular
   font-family: $heading-font-regular
+  weight: normal
 
 %default-font
   font-family: $normal-font


### PR DESCRIPTION
The `font-weight` for FS Elliot types always should be `normal` so I've added this to `%heading-font-regular` and `%heading-font-bold`.
