### PR TITLE
changed the way the placeholder is coloured to be more verbose

### DIFF
--- a/vendor/assets/stylesheets/ustyle/forms/_input.sass
+++ b/vendor/assets/stylesheets/ustyle/forms/_input.sass
@@ -21,12 +21,6 @@
   font-size: 1em
   color: $grey-1
 
-  &::-webkit-input-placeholder,
-  &:-moz-placeholder,
-  &::-moz-placeholder,
-  &:-ms-input-placeholder
-    color: $grey-4
-
   &:hover
     border-color: $input-hover-color
 
@@ -48,4 +42,12 @@
     padding: .635em 0.5em
     height: auto
     font-size: 1.2em
-    
+
+.us-form-input::-webkit-input-placeholder
+  color: $grey-4
+.us-form-input:-moz-placeholder
+  color: $grey-4
+.us-form-input::-moz-placeholder
+  color: $grey-4
+.us-form-input:-ms-input-placeholder
+  color: $grey-4


### PR DESCRIPTION
changed the way the placeholder is coloured to be more verbose (wasn't working as a comma list of selectors, when the render engine finds a selector it doesn't understand, it rejects the whole line apparently)

This wasn't a problem in many browsers (were the defaults were fine), but in IE10+ the placeholder was appearing very dark, text entry dark.

http://css-tricks.com/snippets/css/style-placeholder-text/#comment-96771
