### PR TITLE
Added basic table styles to uStyle together with a more complex example

### DIFF
--- a/styleguide/data/credit_agents.json
+++ b/styleguide/data/credit_agents.json
@@ -1,0 +1,63 @@
+{
+  "experian": {
+    "company_id": "experian",
+    "company_name": "Experian",
+    "trial_period": 30,
+    "monthly_fee": 14.99,
+    "url": "http://www.uswitch.com/gothere?id=1992b40bd19bcc1ebf40",
+    "features": [
+      "Unlimited online access",
+      "Credit score improvement tips",
+      "Identity Fraud Insurance",
+      "Email & SMS alerts"
+    ]
+  },
+  "equifax": {
+    "company_id": "equifax",
+    "company_name": "Equifax",
+    "trial_period": 30,
+    "monthly_fee": 14.95,
+    "url": "http://www.uswitch.com/gothere?id=6fcf3d32849a56d73261",
+    "features": [
+      "Unlimited online access",
+      "Weekly alerts",
+      "Customer support team"
+    ]
+  },
+  "check_my_file": {
+    "company_id": "check_my_file",
+    "company_name": "Check my file",
+    "trial_period": 30,
+    "monthly_fee": 7.99,
+    "url": "http://www.uswitch.com/gothere?id=06fc7baeb9e4c66b944d",
+    "features": [
+      "Three credit agency checks",
+      "Debt advice centre",
+      "Identity theft protection"
+    ]
+  },
+  "check_my_file_oneoff": {
+    "company_id": "check_my_file",
+    "company_name": "Check my file",
+    "trial_period": null,
+    "monthly_fee": 19.99,
+    "fee_desc": "one-off charge",
+    "url": "http://www.uswitch.com/gothere?id=b2c193a78f6dddb8d457",
+    "features": [
+      "One off credit report check",
+      "No monthly subscription"
+    ]
+  },
+  "my_credit_tracker": {
+    "company_id": "my_credit_tracker",
+    "company_name": "My Credit Tracker",
+    "trial_period": 30,
+    "monthly_fee": 7.99,
+    "url": "http://www.uswitch.com/gothere?id=93c57ac5c3e9d8611cfa",
+    "features": [
+      "Unlimited credit report access",
+      "Alerts and tools",
+      "Support to improve credit rating"
+    ]
+  }
+}

--- a/styleguide/source/javascripts/all.js
+++ b/styleguide/source/javascripts/all.js
@@ -1,3 +1,4 @@
 //= require highlight
+//= require tablesort
 //= require ustyle/tabs
 //= require app

--- a/styleguide/source/javascripts/app.js
+++ b/styleguide/source/javascripts/app.js
@@ -6,6 +6,7 @@ uSwitch.styleguide = (function(){
 
   var init = function(){
     setupNav();
+    $('.js-sortable').tableSort();
   };
 
   var setupNav = function(){

--- a/styleguide/source/javascripts/tablesort.js
+++ b/styleguide/source/javascripts/tablesort.js
@@ -1,0 +1,143 @@
+// Table sorter
+// ============
+
+(function ($) {
+  
+  $.fn.tableSort = function(options) {
+
+    var settings = $.extend({
+      autosort: true,
+      th_class_prefix:   'us-table-head',
+      td_class_prefix:   'us-table-cell',
+      sorted_th_class:   'us-table-head-sorted',
+      sorted_td_class:   'us-table-cell-sorted',
+      sort_button_class: 'us-table-sort-button',
+      body_row_class:    'us-table-body-row',
+    }, options);
+
+    return this.each(function() {
+      var $self  = $(this);
+      // Structure for the sort keys
+      var sort_keys = [];
+      // This will hold the pure data relevant to the 
+      // sort, together with the row indexes:
+      var values  = [];
+      // The index for reordering the rows
+      var index   = [];
+
+      function setSort(sort_string) {
+        sort_keys = $.map(sort_string.split(/,\s*/), function(field) {
+          var field_converted = field.split(/\:/);
+          field_converted[1] = field_converted[1] == 'desc' ? -1 : 1;
+          return [field_converted];
+        });
+        values  = [];
+        index   = [];
+      }
+
+      // scroll to top (only if further down the page)
+      function scrollToTop() {
+        var tableTop = $self.offset().top;
+        var currentTop = $(window).scrollTop();
+        if ( tableTop < currentTop ) {
+          $('body,html').animate({
+            scrollTop: $self.offset().top
+          }, 500);
+        }
+      }
+
+      function reorder() {
+        scrollToTop();
+        collectValues();
+        createIndex();
+        rebuildTable();
+      }
+
+      // Collecting values for the sort into an array
+      function collectValues() {
+        $self.find('tr.' + settings.body_row_class).each(function(index) {
+          values[index] = [index];
+          for (fi = 0, l = sort_keys.length; fi < l; fi++) {
+            // We are dealing with ascending / descending order at this point
+            values[index].push( $(this).data(sort_keys[fi][0]) * sort_keys[fi][1] );
+          }
+        });
+      }
+
+      function createIndex() {
+        index = values.sort(function(a, b) {
+          for (var i = 1, l = a.length; i < l; i++) {
+            var diff = a[i] - b[i];
+            if (diff !== 0) return diff;
+          }
+          return 0;
+        });
+        index = $.map(index, function(v) {
+          return v[0];
+        });
+      }
+
+      function rebuildTable() {
+        var detachedRows = [];
+        var assembled_rows = [];
+
+        // HIGLIGHTING the PRIMARY HEADER
+        $self.find('> thead .' + settings.sorted_th_class).removeClass(settings.sorted_th_class);
+        $self.find('> thead .' + settings.th_class_prefix + '-' + sort_keys[0][0]).addClass(settings.sorted_th_class);
+
+        // DETACHING the CURRENT ROWS
+        $self.find('> tbody > tr').each(function(index, main_row) {
+          detachedRows[index] = [ $(main_row).detach() ];
+        });
+
+        // ATTACHING THE ROWS BACK in the right order
+        // ------------------------------------------
+        for(var i = 0, l = index.length; i < l; i++) {
+          var rowToAttach = detachedRows[ index[i] ];
+          // Highlighting the primary column
+          rowToAttach[0].find('td.' + settings.sorted_td_class).removeClass(settings.sorted_td_class);
+          rowToAttach[0].find('td.' + settings.td_class_prefix + '-' + sort_keys[0][0]).addClass(settings.sorted_td_class);
+          // Attaching in memory
+          assembled_rows = assembled_rows.concat( rowToAttach );
+        }
+        
+        // Attaching from memory to the DOM
+        $self.find('tbody').append(assembled_rows);
+      }
+
+      function getSortParam() {
+        var param_match = location.search.match(/sort=([^&]+)(?:&|$)/);
+        return param_match ? decodeURIComponent(param_match[1]) : null;
+      }
+
+      // EVENTS
+      // ------
+
+      // Click on sort buttons
+      $self.on('click', '.' + settings.sort_button_class, function(e) {
+        e.preventDefault();
+        setSort( $(this).data('sort') );
+        reorder();
+      });
+
+      // SORT by the 'sort' URL parameter
+      // --------------------------------
+      var sort_param = getSortParam();
+      if (sort_param) {
+        setSort(sort_param);
+        reorder();
+
+      // AUTOSORT
+      // --------
+      } else if (settings.autosort) {
+        var primary_button = $self.find('thead .' + settings.sorted_th_class + ' .' + settings.sort_button_class);
+        console.log(primary_button);
+        setSort( primary_button.data('sort') );
+        reorder();
+      }
+
+    });
+
+  };
+
+}(jQuery));

--- a/styleguide/source/partials/_nav.haml
+++ b/styleguide/source/partials/_nav.haml
@@ -1,7 +1,7 @@
 %nav#nav
-  .nav-link= nav_link "Grid", "/grid.html"
   .nav-link= nav_link "Typography", "/typography.html"
   .nav-link= nav_link "Forms", "/forms.html"
   .nav-link= nav_link "Buttons", "/buttons.html"
   .nav-link= nav_link "Components", "/components.html"
   .nav-link= nav_link "Grid", "/grid.html"
+  .nav-link= nav_link "Tables", "/tables.html"

--- a/styleguide/source/stylesheets/all.css.sass
+++ b/styleguide/source/stylesheets/all.css.sass
@@ -15,3 +15,7 @@
 @import "modules/grid-example"
 @import "modules/highlight"
 @import "modules/colors"
+@import "modules/tables-sortable"
+@import "modules/tables-with-key-cells"
+@import "modules/tables-example"
+@import "modules/key"

--- a/styleguide/source/stylesheets/modules/_key.sass
+++ b/styleguide/source/stylesheets/modules/_key.sass
@@ -1,0 +1,75 @@
+// Key figures
+// ---
+
+.key-container
+  display: block
+  text-align: center
+
+.key
+  display: block
+  line-height: 1.15
+
+.key-value
+  @extend %heading-font-bold
+  font-size: 24px
+  line-height: 1
+
+.key-textvalue
+  font:
+    weight: bold
+    size: 14px
+
+.key-unit
+  display: block
+  font-size: 14px
+
+  .key-inline &
+    @extend %heading-font-bold
+    display: inline
+    font-size: 20px
+
+.key-sideunit
+  font-size: 18px
+  line-height: 1
+
+.key-desc
+  display: block
+  font-size: 14px
+
+  .key-inline &
+    margin-top: .4em
+
+.key-desc-more
+  display: block
+
+// ----------------------
+// Highlighted key figure
+// ----------------------
+
+.key-container-highlighted
+  @extend .key-container
+  color: $c-typecyan
+
+// -------------------
+// Secondary container
+// -------------------
+
+.key-subcontainer
+  width: 100%
+  box-sizing: border-box
+  padding-top: 3px
+  margin-top: 10px
+  background-color: none
+  font-size: 12px
+
+  .key-value
+    font-size: 18px
+    line-height: 1.2
+
+  .key-sideunit
+    font-size: 12px
+    line-height: 1
+
+  .key-desc
+    line-height: 1
+    font-size: 12px

--- a/styleguide/source/stylesheets/modules/_tables-example.sass
+++ b/styleguide/source/stylesheets/modules/_tables-example.sass
@@ -1,0 +1,38 @@
+.list-in-table
+  margin: 0
+  padding-left: 1em
+
+.table-complex-example
+  .us-table-cell-action
+    text-align: right
+
+  +respond-to(mobile)
+    
+    .us-table-body-row
+      padding: .5em
+      margin-bottom: 1em
+      border: 1px solid tint($c-darkgrey, 75%)
+
+    .us-table-cell-title
+      +adjust-font-size-to(18px)
+      color: $c-darkgrey
+      margin-bottom: .5em
+
+    .us-table-cell-key
+      float: left
+      width: 50%
+      margin-bottom: 1em
+    
+    .us-table-cell-action
+      clear: both
+      text-align: center
+    
+    .list-in-table
+      margin-bottom: 1em
+      li
+        margin-bottom: 0
+
+  +respond-to(small-tablet)
+
+    .key-desc-more
+      display: none

--- a/styleguide/source/stylesheets/modules/_tables-sortable.sass
+++ b/styleguide/source/stylesheets/modules/_tables-sortable.sass
@@ -1,0 +1,54 @@
+%with-sort-arrow
+
+  +respond-to(small-tablet, true)
+    position: relative
+    margin-right: .4em
+
+    &:after
+      display: none
+      content: "\025bc"
+      line-height: 1
+      position: absolute
+      top: 50%
+      right: -1.2em
+      margin-top: -.4em
+      color: $table-c-inactive
+
+.us-table-cell-sorted
+
+  +respond-to(small-tablet, true)
+    background: $table-c-sorted-bg
+
+%us-table-head-text,
+.us-table-head-text
+  @extend %with-sort-arrow
+  +inline-block
+  line-height: normal
+  vertical-align: baseline
+
+.us-table-sort-button,
+.us-table-sort-button:visited
+  @extend %us-table-head-text
+
+  +respond-to(small-tablet, true)
+    color: $table-c-head-text
+    cursor: default
+
+    .js .js-sortable &
+      cursor: pointer
+
+      &:after
+        display: block
+      
+      &:hover
+        color: $table-c-head-text
+
+        &:after
+          color: $table-c-head-text
+
+.us-table-head-sorted
+  .us-table-sort-button,
+  .us-table-head-text
+    &:after
+      display: block
+      color: $table-c-head-text

--- a/styleguide/source/stylesheets/modules/_tables-with-key-cells.sass
+++ b/styleguide/source/stylesheets/modules/_tables-with-key-cells.sass
@@ -1,0 +1,23 @@
+// Table with key cells
+// --------------------
+
+.us-table-head-key
+  text-align: center
+  padding-left: 1em
+  padding-right: 1em
+
+  .us-table-sort-button
+    margin-right: 0
+
+.us-table-cell-key
+  text-align: center
+
+  .key-value,
+  .key-sideunit
+    color: $table-c-key
+
+  +respond-to(small-tablet, true)
+    width: em($table-key-width)
+    max-width: em($table-key-width)
+    padding-left:  em($table-key-sidepadding)
+    padding-right: em($table-key-sidepadding)

--- a/styleguide/source/tables.haml
+++ b/styleguide/source/tables.haml
@@ -1,0 +1,92 @@
+.us-container
+  %h1 Tables
+
+.us-container
+  = styleblock "6.1", "A basic table", false do
+    %table.us-table
+      %thead
+        %tr
+          %th.us-table-head
+            Company
+          %th.us-table-head
+            Product features
+          %th.us-table-head
+            Free trial period
+          %th.us-table-head
+            Monthly subscription
+          %th.us-table-head
+
+      %tbody
+        - data.credit_agents.each do |id, agent|
+          %tr.us-table-body-row
+            %td.us-table-cell= agent.company_name
+            %td.us-table-cell
+              %ul.list-in-table
+                - agent.features.each do |feature|
+                  %li= feature
+            %td.us-table-cell
+              - if agent.trial_period
+                = agent.trial_period
+                days
+              - else
+                = "—"
+            %td.us-table-cell
+              £#{agent.monthly_fee}
+              - if agent.fee_desc
+                = agent.fee_desc
+            %td.us-table-cell
+              %a.us-btn.arrowed{href: agent.url, target: "_blank"} Proceed
+
+-# -------
+
+.us-container
+  %h2 Example of a more complex table
+  = styleblock "6.2", "Example of a more complex table", false do
+    %table.us-table.js-sortable.table-complex-example
+      %thead
+        %tr
+          %th.us-table-head
+            Company
+          %th.us-table-head
+            Product features
+          %th.us-table-head.us-table-head-key.us-table-head-trial-period.us-table-head-sorted
+            %a.us-table-sort-button{data: {sort: "trial-period:desc, fee"}}
+              Free trial period
+          %th.us-table-head.us-table-head-key.us-table-head-fee
+            %a.us-table-sort-button{data: {sort: "fee, trial-period:desc"}}
+              Monthly subscription
+          %th.us-table-head
+
+      %tbody
+        - data.credit_agents.each do |id, agent|
+          %tr.us-table-body-row{data: {trial_period: agent.trial_period || 0, fee: agent.monthly_fee || 9999}}
+            %td.us-table-cell.us-table-cell-title
+              %strong= agent.company_name
+            %td.us-table-cell.us-table-cell-features
+              %ul.list-in-table
+                - agent.features.each do |feature|
+                  %li= feature
+            %td.us-table-cell.us-table-cell-key.us-table-cell-trial-period.us-table-cell-sorted
+              .key-container
+                .key
+                  - if agent.trial_period
+                    .key-value= agent.trial_period
+                    .key-unit days
+                    .key-desc
+                      .key-desc-more
+                        free trial period
+                  - else
+                    = "—"
+            %td.us-table-cell.us-table-cell-key.us-table-cell-fee
+              .key-container
+                .key
+                  .key-value £#{agent.monthly_fee}
+                  .key-desc
+                    - if agent.fee_desc
+                      = agent.fee_desc
+                    - else
+                      .key-desc-more
+                        monthly fee
+
+            %td.us-table-cell.us-table-cell-action
+              %a.us-btn.arrowed{href: agent.url, target: "_blank"} Proceed

--- a/vendor/assets/stylesheets/ustyle/_all.sass
+++ b/vendor/assets/stylesheets/ustyle/_all.sass
@@ -33,3 +33,6 @@
 
 // Forms
 @import "ustyle/forms/base"
+
+// Tables
+@import "ustyle/tables/base"

--- a/vendor/assets/stylesheets/ustyle/tables/_base.sass
+++ b/vendor/assets/stylesheets/ustyle/tables/_base.sass
@@ -1,0 +1,5 @@
+@import "ustyle/tables/variables"
+@import "ustyle/tables/tables-basic"
+@import "ustyle/tables/tables-sortable"
+// @import "ustyle/tables/tables-with-key-cells"
+

--- a/vendor/assets/stylesheets/ustyle/tables/_tables-basic.sass
+++ b/vendor/assets/stylesheets/ustyle/tables/_tables-basic.sass
@@ -1,0 +1,55 @@
+// Basic table
+// ---
+// The most basic comparison table structure. It defines the style of the the
+// table only, the look of the content is totally up to you. On small screens
+// the table components become block elements, with only minimal styles applied,
+// so you don't need to overwrite too many default style rules when customising
+// the mobile appearance.
+//
+// Styleguide 6.1
+
+
+.us-table
+  // +adjust-font-size-to($table-font-size)
+  width: 100%
+  border-collapse: separate
+  border-spacing: 0
+  color: $table-c-text
+
+  +respond-to(mobile)
+    thead
+      display: none !important
+
+    // !! This affects tables inside the table
+    tbody,
+    tr,
+    td
+      display: block
+
+
+// Normal table headers
+
+.us-table-head
+  padding: 0 1em .5em 0
+  border-bottom: 1px solid $table-c-border
+  color: $table-c-head-text
+  text-align: left
+  vertical-align: middle
+
+// Main rows
+
+.us-table-body-row
+
+  +respond-to(mobile)
+    +pie-clearfix
+    position: relative
+
+.us-table-cell
+  padding: 1em 0
+  border-bottom: 1px solid $table-c-border
+  text-align: left
+  vertical-align: top
+  
+  +respond-to(mobile)
+    padding: 0
+    border: none

--- a/vendor/assets/stylesheets/ustyle/tables/_tables-sortable.sass
+++ b/vendor/assets/stylesheets/ustyle/tables/_tables-sortable.sass
@@ -1,0 +1,56 @@
+// Styleguide 6.2
+
+// %with-sort-arrow
+
+//   +respond-to(small-tablet, true)
+//     position: relative
+//     margin-right: .4em
+
+//     &:after
+//       display: none
+//       content: "\025bc"
+//       line-height: 1
+//       position: absolute
+//       top: 50%
+//       right: -1.2em
+//       margin-top: -.4em
+//       color: $table-c-inactive
+
+// .us-table-cell-sorted
+
+//   +respond-to(small-tablet, true)
+//     background: $table-c-sorted-bg
+
+// %us-table-head-text,
+// .us-table-head-text
+//   @extend %with-sort-arrow
+//   +inline-block
+//   line-height: normal
+//   vertical-align: baseline
+
+// .us-table-sort-button,
+// .us-table-sort-button:visited
+//   @extend %us-table-head-text
+
+//   +respond-to(small-tablet, true)
+//     color: $table-c-head-text
+//     cursor: default
+
+//     .js .js-sortable &
+//       cursor: pointer
+
+//       &:after
+//         display: block
+      
+//       &:hover
+//         color: $table-c-head-text
+
+//         &:after
+//           color: $table-c-head-text
+
+// .us-table-head-sorted
+//   .us-table-sort-button,
+//   .us-table-head-text
+//     &:after
+//       display: block
+//       color: $table-c-head-text

--- a/vendor/assets/stylesheets/ustyle/tables/_tables-with-key-cells.sass
+++ b/vendor/assets/stylesheets/ustyle/tables/_tables-with-key-cells.sass
@@ -1,0 +1,14 @@
+// Table with key cells
+// --------------------
+
+.us-table-cell-key
+
+  .key-value,
+  .key-sideunit
+    color: $table-c-key
+
+  +respond-to(small-tablet, true)
+    width: em($table-key-width)
+    max-width: em($table-key-width)
+    padding-left:  em($table-key-sidepadding)
+    padding-right: em($table-key-sidepadding)

--- a/vendor/assets/stylesheets/ustyle/tables/_variables.sass
+++ b/vendor/assets/stylesheets/ustyle/tables/_variables.sass
@@ -1,0 +1,13 @@
+$table-font-size: 14px !default
+
+$table-c-text:      tint($c-darkgrey, 25%) !default
+$table-c-border:    tint($c-darkgrey, 75%) !default
+$table-c-head-text: $c-navy !default
+$table-c-head-bg:   white !default
+$table-c-body-bg:   white !default
+$table-c-key:       $c-navy !default
+$table-c-sorted-bg: tint($c-cyan, 75%) !default
+$table-c-inactive:  tint($c-darkgrey, 75%) !default
+
+$table-key-width:       150px !default
+$table-key-sidepadding: 10px !default


### PR DESCRIPTION
I've added the very basic, stripped-down comparison table styles to uStyle. This can be a good starting point to build something more interesting.

Also added a more complex table example, only to the style guide, with sortable columns and styled content.
