### PR TITLE
Hoping to fix the "max" media queries

### DIFF
--- a/vendor/assets/stylesheets/ustyle/mixins/_media_query.sass
+++ b/vendor/assets/stylesheets/ustyle/mixins/_media_query.sass
@@ -12,15 +12,30 @@ $small-tablet-width:  em(600px) !default
 $mobile-width:        em(480px) !default
 
 $mobile-end-width: ""
-
 @if unit($small-tablet-width) == "px"
   $mobile-end-width: $small-tablet-width - 1
 @else
   $mobile-end-width: $small-tablet-width - em(1px)
 
-$tablet-end: $tablet-width + 1
+$small-tablet-end-width: ""
+@if unit($tablet-width) == "px"
+  $small-tablet-end-width: $tablet-width - 1
+@else
+  $small-tablet-end-width: $tablet-width - em(1px)
 
-$devices: (mobile, max, ($small-tablet-width)), (small-tablet, min, $small-tablet-width), (tablet, min, $tablet-width), (to-tablet, max, $tablet-width), (from-tablet, min, $tablet-end), (to-desktop, max, $desktop-width), (desktop, min, $desktop-width), (large-desktop, min, $large-desktop-width) !default
+$tablet-end-width: ""
+@if unit($desktop-width) == "px"
+  $tablet-end-width: $desktop-width - 1
+@else
+  $tablet-end-width: $desktop-width - em(1px)
+
+$desktop-end-width: ""
+@if unit($large-desktop-width) == "px"
+  $desktop-end-width: $large-desktop-width - 1
+@else
+  $desktop-end-width: $large-desktop-width - em(1px)
+
+$devices: (mobile, max, $mobile-end-width), (small-tablet, min, $small-tablet-width), (to-small-tablet, max, $small-tablet-end-width), (tablet, min, $tablet-width), (to-tablet, max, $tablet-end-width), (from-tablet, min, $tablet-end-width), (desktop, min, $desktop-width), (to-desktop, max, $desktop-end-width), (large-desktop, min, $large-desktop-width) !default
 
 = respond-to($device, $ie-fallback: false, $ie-fallback-noherit: false)
 


### PR DESCRIPTION
Fix the "max" media queries - especially the "mobile" one. Currently we have +respond-to(mobile) which is up to and including 600px and +respond-to(small-tablet) which is 600px or greater - leading to problems on the cusp of 600px, which falls into both rules. This fix changes +respond-to(mobile) to be up to and including 599px.

This was especially noticeable on the Nexus 7 - where the mk1 had a 601px viewport and pulled the small-tablet rules, the mk2 is 600px wide and often pulls a mix of mobile and small-tablet rules (depending on which rules were ustyle mixin generated or those that were added manually). This "could" fix the main site nav appearing slightly broken on the Nexus7 mk2.

The other "to-" queries have been made more consistent and set to the top of that range (eg, "to-desktop" is "all sizes up to large-desktop minus 1px"). _This could be a breaking change_, but I haven't seen the "to-" queries used much (apart from "mobile"). Homepage maybe?
