### PR TITLE
changed us-row mixin to respond from small-tablet instead of tablet caus...

### DIFF
--- a/vendor/assets/stylesheets/ustyle/basics/_grid.sass
+++ b/vendor/assets/stylesheets/ustyle/basics/_grid.sass
@@ -26,7 +26,7 @@
 
 @mixin us-row
   @extend %clearfix
-  +respond-to(tablet, true)
+  +respond-to(small-tablet, true)
     margin-left: - $gutter-width / 2
     margin-right: - $gutter-width / 2
 


### PR DESCRIPTION
...ing oddities in spacing

I'm having to add this to fix currently:

``` scss
@include respond-to(small-tablet) {
    margin-left: -15px;
    margin-right: -15px;
}
```

As in the _grid.sass it only starts from tablet media query

Without fix:
![screenshot 2014-06-17 10 43 43](https://cloud.githubusercontent.com/assets/272787/3298607/e7c44386-f603-11e3-8288-aa89980988b5.png)

With fix:
![screenshot 2014-06-17 10 44 41](https://cloud.githubusercontent.com/assets/272787/3298618/08592e72-f604-11e3-9415-ae0c4c1211b9.png)
