### PR TITLE
Small tablet includes nav fix

### DIFF
--- a/vendor/assets/stylesheets/ustyle/structure/_navigation.sass
+++ b/vendor/assets/stylesheets/ustyle/structure/_navigation.sass
@@ -133,7 +133,7 @@
     +link-colors(#039, #039, #039, #039)
 
   +respond-to(small-tablet, true)
-    padding: 8px 6px 11px 6px
+    padding: 8px 5px 11px 6px
     border: 1px solid transparent
     border-bottom: none
 


### PR DESCRIPTION
![small-tablet](https://cloud.githubusercontent.com/assets/1090350/3387474/9e1ec11c-fc7e-11e3-93ec-0d51a797984e.jpg)

attempting to fix two bugs in main navigation on small tablets, specifically nexus 7 or 600px wide viewport,:
- link text was text-wrapping
- the search menu drops of the end
