### PR TITLE
funnel header: change tel number font from elliot to open-sans

### DIFF
--- a/vendor/assets/stylesheets/ustyle/structure/_funnel.sass
+++ b/vendor/assets/stylesheets/ustyle/structure/_funnel.sass
@@ -6,12 +6,14 @@
     position: absolute
     right: 2em
     top: -14px
-
     +heading-font-regular
     +adjust-font-size-to(16px)
     color: $grey-5
     font-weight: normal
-    letter-spacing: -0.05em
+    h3
+      font-size: 1em
+      font-weight: normal
+      font-family: inherit
 
   .tel
     a


### PR DESCRIPTION
funnel header had telephone number in 16px in Elliot bold - not the greatest.
