### PR TITLE
FS Elliot -> Open Sans for headings when printing

### DIFF
--- a/vendor/assets/stylesheets/ustyle/basics/_fonts.sass
+++ b/vendor/assets/stylesheets/ustyle/basics/_fonts.sass
@@ -14,6 +14,12 @@
     family: $heading-font-secondary
     weight: 700
 
+%heading-font-print
+  @media print
+    font:
+      family: $heading-font-secondary !important
+      weight: 700 !important
+
 %default-font,
 %normal-font
   font-family: $normal-font

--- a/vendor/assets/stylesheets/ustyle/mixins/_typography.sass
+++ b/vendor/assets/stylesheets/ustyle/mixins/_typography.sass
@@ -20,6 +20,7 @@
     font:
       family: $heading-font-primary
       weight: normal
+  @extend %heading-font-print
 
 = heading-font-secondary($extend: true)
   @if $extend


### PR DESCRIPTION
Added a new placeholder which forces the use of Open Sans when the current media type matches print. At the moment this placeholder is being used in the `=heading-font-primary` mixin, so everyone who's using that to declare the font family for a selector should automatically find it using Open Sans when printing.
