### PR TITLE
Autoprefixer configuration defaults

### DIFF
--- a/config/autoprefixer.yml
+++ b/config/autoprefixer.yml
@@ -1,0 +1,6 @@
+browsers:
+  - "last 5 versions"
+  - "Firefox 22"
+  - "Opera 12.1"
+  - "> 1%"
+  - "Explorer 8"

--- a/lib/ustyle.rb
+++ b/lib/ustyle.rb
@@ -44,6 +44,14 @@ module Ustyle
       @sprockets_env ||= ::Sprockets::Environment.new
     end
 
+    def autoprefixer_config app
+      file   = File.join Ustyle.gem_path, 'config/autoprefixer.yml'
+      params = YAML.load_file(file).symbolize_keys
+      opts   = { }
+      opts[:safe] = true if params.delete(:safe)
+      [params, opts]
+    end
+
     def register_compass_extension
       ::Compass::Frameworks.register(
           "ustyle",

--- a/lib/ustyle/engine.rb
+++ b/lib/ustyle/engine.rb
@@ -1,3 +1,5 @@
+require 'autoprefixer-rails'
+
 module Ustyle
   class Engine < ::Rails::Engine
     add_paths_block = lambda { |app|
@@ -13,6 +15,10 @@ module Ustyle
     initializer "ustyle.update_asset_paths", &add_paths_block
     initializer "ustyle.update_asset_paths", group: :assets, &add_paths_block
   end
-end
 
-require 'autoprefixer-rails'
+  class Railtie < ::Rails::Railtie
+    initializer :setup_autoprefixer, group: :all do |app|
+      AutoprefixerRails.install(app.assets, *Ustyle.autoprefixer_config(app))
+    end
+  end
+end

--- a/lib/ustyle/sinatra.rb
+++ b/lib/ustyle/sinatra.rb
@@ -24,7 +24,7 @@ if defined?(::Sinatra)
         end
 
         require 'autoprefixer-rails'
-        AutoprefixerRails.install(app.sprockets)
+        AutoprefixerRails.install(app.sprockets, *::Ustyle.autoprefixer_config(app))
 
         app.helpers Sprockets::Helpers
       end


### PR DESCRIPTION
This fixes the issues where autoprefixer was removing `-moz-box-sizing` from our apps (due to Firefox ESR support) and sets a standard default for going forward on all our apps.

The settings are:

``` yaml
browsers:
  - "last 5 versions"
  - "Firefox 22"
  - "Opera 12.1"
  - "> 1%"
  - "Explorer 8"
```

I still need to figure out a way to patch this in to any Javascript app. Anybody want to take a stab at creating generators for a Node app? I think it would be useful.
