### PR TITLE
Close the overlay when the escape key is pressed

### DIFF
--- a/vendor/assets/javascripts/ustyle/overlay.js.coffee
+++ b/vendor/assets/javascripts/ustyle/overlay.js.coffee
@@ -19,7 +19,7 @@ class window.Overlay
       @show()
     @options.closeButton.on 'click', (e)=>
       @hide()
-    $(document).on 'keydown', (e)=>
+    $(document).on 'keyup', (e)=>
       ESCAPE_KEY = 27
       if e.keyCode == ESCAPE_KEY
         @hide()


### PR DESCRIPTION
Close the overlay popup(?) when the escape key is pressed as is typical behaviour with many popupy components.
It was annoying the shit out of me so I fixed it. Hurrah!
