### PR TITLE
Bower Compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,45 @@
+{
+  "name": "ustyle",
+  "version": "0.14.4",
+  "main": [
+    "build/ustyle-latest.css",
+    "build/ustyle-icons.css",
+    "build/ustyle.js"
+  ],
+  "homepage": "https://github.com/uswitch/ustyle",
+  "authors": [
+    "Joe Green <joe.green@uswitch.com>"
+  ],
+  "description": "A front-end framework by uSwitch.",
+  "keywords": [
+    "css",
+    "sass",
+    "scss",
+    "js",
+    "javascript",
+    "front-end",
+    "uswitch",
+    "ustyle"
+  ],
+  "license": "MIT",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "bin",
+    "config",
+    "grunt",
+    "lib",
+    "node_modules",
+    "styleguide",
+    "tasks",
+    "CONTRIBUTING.md",
+    "Gemfile",
+    "Gemfile.lock",
+    "Gruntfile.js",
+    "icon-upgrade.md",
+    "package.json",
+    "Rakefile",
+    "README.md",
+    "ustyle.gemspec"
+  ]
+}


### PR DESCRIPTION
I've added a bower.json file to the project for people who wish to use uStyle without building it themselves.

I'm a bit unsure of exactly how the "ignore" property works; we'll have to experiment and see if it does indeed prevent those files and folders from being cloned when someone does `bower install ustyle`.
