### PR TITLE
Cached stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ tmp
 docs/
 .sass-cache/
 node_modules/
-dist/.stats-cache

--- a/grunt/tasks/styleguide.js
+++ b/grunt/tasks/styleguide.js
@@ -167,7 +167,7 @@ module.exports = function(grunt){
       var cssFileData, selectors, cssParser,
           omitEntries, statsPage, cachedStatsFile;
 
-      cachedStatsFile = 'dist/.stats-cache';
+      cachedStatsFile = 'tmp/.stats-cache';
 
       statsPage = {
         name: 'Stats',


### PR DESCRIPTION
We now cache stats. If the cached version of stats is different from the current git tag or we haven't cached already, we'll fetch new data and cache it. 
