### PR TITLE
Fix for radio toggles with a nested name (i.e. name=field1[field2])

### DIFF
--- a/vendor/assets/javascripts/ustyle/radioToggle.js.coffee
+++ b/vendor/assets/javascripts/ustyle/radioToggle.js.coffee
@@ -11,6 +11,6 @@ class window.RadioToggle
 
   addEventListeners: ->
     @options.$target.on "change", "input:radio", (e) ->
-      $("input[name=#{this.name}]").removeClass("checked")
+      $("input[name='#{this.name}']").removeClass("checked")
       $(this).addClass("checked") if this.checked
       e.stopPropagation()


### PR DESCRIPTION
The radio toggle javascript was throwing an error when the name of the radio input was nested, for example in energy-main-process supplier_info[dual_fuel_supplier_key]. Enclosing the name in single quotes fixes this.
