### PR TITLE
Set the maximum width of a select to 100% so that it doesn't overflow

### DIFF
--- a/vendor/assets/stylesheets/ustyle/forms/_select.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_select.scss
@@ -53,6 +53,7 @@ $select-hover-color: $c-form-element-border-hover !default;
   background-position: 100% 50%;
   background-repeat: no-repeat;
   outline: 0;
+  max-width: 100%;
 
   // [nodoc] Fix for FF < 35 https://gist.github.com/joaocunha/6273016/
   @-moz-document url-prefix() {


### PR DESCRIPTION
Following an update to the version of ustyle we had a problem with selects (dropdowns) overflowing on the page for smaller devices.