### PR TITLE
Update the version of autoprefixer-rails

### DIFF
--- a/config/autoprefixer.yml
+++ b/config/autoprefixer.yml
@@ -1,6 +1,6 @@
 browsers:
   - "last 5 versions"
-  - "Firefox 22"
-  - "Opera 12.1"
+  - "Firefox >= 22"
+  - "Opera >= 12.1"
   - "> 1%"
-  - "Explorer 8"
+  - "not Explorer < 8"

--- a/lib/ustyle.rb
+++ b/lib/ustyle.rb
@@ -44,9 +44,7 @@ module Ustyle
     def autoprefixer_config
       file   = File.join Ustyle.gem_path, 'config/autoprefixer.yml'
       params = YAML.load_file(file).symbolize_keys
-      opts   = { }
-      opts[:safe] = true if params.delete(:safe)
-      [params, opts]
+      params
     end
   end
 end

--- a/lib/ustyle.rb
+++ b/lib/ustyle.rb
@@ -41,7 +41,7 @@ module Ustyle
       @sprockets_env ||= ::Sprockets::Environment.new
     end
 
-    def autoprefixer_config app
+    def autoprefixer_config
       file   = File.join Ustyle.gem_path, 'config/autoprefixer.yml'
       params = YAML.load_file(file).symbolize_keys
       opts   = { }

--- a/lib/ustyle/engine.rb
+++ b/lib/ustyle/engine.rb
@@ -16,9 +16,4 @@ module Ustyle
     initializer "ustyle.update_asset_paths", group: :assets, &add_paths_block
   end
 
-  class Railtie < ::Rails::Railtie
-    initializer :setup_autoprefixer, group: :all do |app|
-      AutoprefixerRails.install(app.assets, *Ustyle.autoprefixer_config(app))
-    end
-  end
 end

--- a/lib/ustyle/engine.rb
+++ b/lib/ustyle/engine.rb
@@ -16,4 +16,17 @@ module Ustyle
     initializer "ustyle.update_asset_paths", group: :assets, &add_paths_block
   end
 
+  class Railtie < ::Rails::Railtie
+    if config.respond_to?(:assets) and not config.assets.nil?
+      config.assets.configure do |env|
+        AutoprefixerRails.install(env, Ustyle.autoprefixer_config)
+      end
+    else
+      initializer :setup_autoprefixer, group: :all do |app|
+        if defined? app.assets and not app.assets.nil?
+          AutoprefixerRails.install(app.assets, Ustyle.autoprefixer_config)
+        end
+      end
+    end
+  end
 end

--- a/lib/ustyle/sinatra.rb
+++ b/lib/ustyle/sinatra.rb
@@ -24,7 +24,7 @@ if defined?(::Sinatra)
         end
 
         require 'autoprefixer-rails'
-        AutoprefixerRails.install(app.sprockets, *::Ustyle.autoprefixer_config(app))
+        AutoprefixerRails.install(app.sprockets, ::Ustyle.autoprefixer_config)
 
         app.helpers Sprockets::Helpers
       end

--- a/ustyle.gemspec
+++ b/ustyle.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "sass"
-  spec.add_dependency "autoprefixer-rails", "~> 4.0"
+  spec.add_dependency "autoprefixer-rails"
   spec.add_dependency "mime-types"
   spec.add_dependency "chunky_png",  ">= 0.8.0"
 


### PR DESCRIPTION
The latest version of the autoprefixer-rails is required for the latest version of rails/sprockets. The gem now does the railtie stuff for you so no longer need to do it install within ustyle. 