### PR TITLE
Selects are now the same height as text inputs

### DIFF
--- a/vendor/assets/stylesheets/ustyle/forms/_input.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_input.scss
@@ -19,29 +19,6 @@
 
 $input-placeholder-color: $c-inputgrey !default;
 
-/// Creates a larger version of a form input, allows us to set the styles
-/// in a responsive manner
-///
-/// @author David Annez
-/// @group Forms
-///
-/// @param {String} $input-size [base]
-///   Name of the size used in the form element list
-///
-/// @param {List} $input-sizes [$form-element-sizes]
-///   List of sizes to pass through. Should contain 4 values per item,
-///   `(size-name, height, padding, font-size)`
-
-@mixin input-sizing($input-size: base, $input-sizes: $form-element-sizes) {
-  @each $size in $input-sizes {
-    @if nth($size, 1) == $input-size {
-      height: nth($size, 2);
-      padding: nth($size, 3);
-      font-size: nth($size, 4);
-    }
-  }
-}
-
 .us-form-input {
   @extend %base-form-element;
   @extend %input-background--normalise;

--- a/vendor/assets/stylesheets/ustyle/forms/_select.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_select.scss
@@ -21,7 +21,6 @@
 //     <option>And a few more</option>
 //   </select>
 
-$select-base-padding: 5px 10px !default;
 $select-default-color: $c-form-element-border !default;
 $select-hover-color: $c-form-element-border-hover !default;
 
@@ -47,8 +46,8 @@ $select-hover-color: $c-form-element-border-hover !default;
 .us-form-select {
   @extend %base-form-element;
   @include select-background($select-default-color, $select-hover-color);
+  @include input-sizing();
   max-width: 100%;
-  padding: $select-base-padding;
   padding-right: 40px;
   cursor: pointer;
   background-position: 100% 50%;
@@ -74,7 +73,7 @@ $select-hover-color: $c-form-element-border-hover !default;
 
   .ie8 &,
   .ie9 & {
-    padding: $select-base-padding;
+    padding: $form-element-base-padding;
   }
 }
 
@@ -85,7 +84,6 @@ $select-hover-color: $c-form-element-border-hover !default;
   &,
   .us-form-select {
     height: auto;
-    padding: $select-base-padding;
     overflow: hidden {
       x: auto;
       y: auto;

--- a/vendor/assets/stylesheets/ustyle/mixins/_forms.scss
+++ b/vendor/assets/stylesheets/ustyle/mixins/_forms.scss
@@ -60,3 +60,26 @@
     box-shadow: none;
   }
 }
+
+/// Creates a larger version of a form input, allows us to set the styles
+/// in a responsive manner
+///
+/// @author David Annez
+/// @group Forms
+///
+/// @param {String} $input-size [base]
+///   Name of the size used in the form element list
+///
+/// @param {List} $input-sizes [$form-element-sizes]
+///   List of sizes to pass through. Should contain 4 values per item,
+///   `(size-name, height, padding, font-size)`
+
+@mixin input-sizing($input-size: base, $input-sizes: $form-element-sizes) {
+  @each $size in $input-sizes {
+    @if nth($size, 1) == $input-size {
+      height: nth($size, 2);
+      padding: nth($size, 3);
+      font-size: nth($size, 4);
+    }
+  }
+}


### PR DESCRIPTION
Select boxes weren't using the same padding as other form inputs, and looked a bit shorter when sitting inline with other elements.