### PR TITLE
docs: clarify that the team uses ESLint

### DIFF
--- a/JAVASCRIPT_STANDARDS.md
+++ b/JAVASCRIPT_STANDARDS.md
@@ -2,7 +2,7 @@
 
 ### INTRODUCTION
 
-We are using [JSCS](http://jscs.info/) to lint our javascript code within uStyle.
+We are using [ESLint](http://eslint.org/) to lint our javascript code within uStyle.
 
 ### RULES
 


### PR DESCRIPTION
JSCS merged into ESLint in April 2016.
I have it on good authority that the team uses ESLint!

🌟 