### PR TITLE
fix: remove reference to non-existent 'grunt test'

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "repository": "uswitch/ustyle",
   "scripts": {
-    "test": "grunt test"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
     "async": "^0.9.0",


### PR DESCRIPTION
Getting set up and running through `package.json`, I noticed that `grunt test` isn't actually an existing `grunt` script. So, I replaced the `test` script in `package.json` with the default test command that comes from a fresh `npm init`. Quick to change, should we write a `test` task.

🌟 