### PR TITLE
fix: pattern library typos, images and formatting

### DIFF
--- a/styleguide/content/pattern-library/grid.tpl
+++ b/styleguide/content/pattern-library/grid.tpl
@@ -3,15 +3,15 @@
     Our grid is a 12 column grid, with similar sizes to that of Bootstrap. We also adhere to the same naming standards for device breakpoints.
   </p>
   <ul>
-    <li>Default gutter width: <strong>15px either side</strong></li>
-    <li>Large container width: <strong>1170px</strong></li>
-    <li>Desktop container width: <strong>970px</strong></li>
-    <li>Tablet container width: <strong>770px</strong></li>
+    <li>Default gutter width: <strong>15px either side</strong>.</li>
+    <li>Large container width: <strong>1170px</strong>.</li>
+    <li>Desktop container width: <strong>970px</strong>.</li>
+    <li>Tablet container width: <strong>770px</strong>.</li>
   </ul>
   <ul>
     <li>The parent container is <code>.us-container</code>, you must have this to start building the uSwitch layouts.</li>
-    <li><code>.us-grid-row</code> is then used when you are building rows of columns (gives a negative margin to the container so they align correctly)</li>
-    <li>All grid class names are prefixed with <code>.us-col-</code></li>
+    <li><code>.us-grid-row</code> is then used when you are building rows of columns (gives a negative margin to the container so they align correctly).</li>
+    <li>All grid class names are prefixed with <code>.us-col-</code>.</li>
   </ul>
 </div>
 <div class="styleguide__block">

--- a/styleguide/content/pattern-library/index.tpl
+++ b/styleguide/content/pattern-library/index.tpl
@@ -3,9 +3,9 @@ template: simple.tpl
 name: Introduction
 ---
 <p>
-  Our pattern library comes as a easily distributed package, ready to use in multiple programming environments. It contains our basic CSS components and correct usage, as well as JavaScript components that are widely used across the website.
+  Our pattern library comes as an easily distributed package, ready to use in multiple programming environments. It contains our basic CSS components and correct usage, as well as JavaScript components that are widely used across the website.
 </p>
-<a class="us-btn us-btn--small" href="http://github.com/uswitch/ustyle">View on github</a>
+<a class="us-btn us-btn--small" href="https://github.com/uswitch/ustyle">View on GitHub</a>
 <div class="us-content-group mobile-bordered">
   <h2 class="trailered">Distribution methods</h2>
   <div class="us-grid-row">
@@ -18,7 +18,7 @@ name: Introduction
     <div class="us-col-md-6 trailered">
       <img src="/images/bower-logo.png" alt="Bower logo" class="distro-image">
       <h3>Bower package</h3>
-      <p>Install is as a bower package. This will pull down the original <code>.scss</code> files and compiled static CSS + JS.</p>
+      <p>Install it as a bower package. This will pull down the original <code>.scss</code> files and compiled static CSS + JS.</p>
       <pre><code class="javascript">
         "dependencies": {
           "ustyle": "git@github.com:uswitch/ustyle.git#~0.19.1"
@@ -88,5 +88,5 @@ name: Introduction
 </div>
 <div class="us-content-group mobile-bordered">
   <h2>Installation</h2>
-  <p>See our github for documentation on installing this across applications.</p>
+  <p>See our <a href="https://github.com/uswitch/ustyle">GitHub</a> for documentation on installing this across applications.</p>
 </div>

--- a/vendor/assets/stylesheets/ustyle/articles/_base.scss
+++ b/vendor/assets/stylesheets/ustyle/articles/_base.scss
@@ -20,7 +20,7 @@
 //           </div>
 //         </div>
 //         <div class='us-col-md-4 us-tablet--block'>
-//           <img class='us-img--full us-article__image' src='http://www.uswitch.com/insurance/assets/guide-home-16141c84afd29e2063ee76803037716c.jpg' />
+//           <img class='us-img--full us-article__image' src='http://uswitch-wp-cms-assets.s3-website-eu-west-1.amazonaws.com/money/guides/wp-content/uploads/2014/11/DB2011AU01018_SMALL.jpg' />
 //         </div>
 //       </a>
 //     </div>

--- a/vendor/assets/stylesheets/ustyle/articles/_guide.scss
+++ b/vendor/assets/stylesheets/ustyle/articles/_guide.scss
@@ -9,7 +9,7 @@
 //     <div class='us-guide-item us-col-md-4'>
 //       <a class='us-guide-item-link' href='#'>
 //         <div class='us-guide-item-image-container'>
-//           <div class='us-guide-item-image background' style='background-image: url(http://www.uswitch.com/insurance/assets/guide-home-16141c84afd29e2063ee76803037716c.jpg)'></div>
+//           <div class='us-guide-item-image background' style='background-image: url(http://uswitch-wp-cms-assets.s3-website-eu-west-1.amazonaws.com/money/guides/wp-content/uploads/2014/11/DB2011AU01018_SMALL.jpg)'></div>
 //         </div>
 //         <div class='us-guide-item-content'>
 //           <h4 class='us-guide-item-title'>Car insurance guides</h4>

--- a/vendor/assets/stylesheets/ustyle/articles/_more.scss
+++ b/vendor/assets/stylesheets/ustyle/articles/_more.scss
@@ -2,7 +2,7 @@
 // @name More article
 //
 // @description
-//   If the article listing has more in a category, we use this to let a user navigate to that category
+//   If the article listing has more in a category, we use this to let a user navigate to that category.
 //
 // @markup
 //   <div class='us-more-item us-col-md-4'>

--- a/vendor/assets/stylesheets/ustyle/articles/_related.scss
+++ b/vendor/assets/stylesheets/ustyle/articles/_related.scss
@@ -1,8 +1,8 @@
 // @page Pattern Library/Articles
 // @name Related items
-// 
+//
 // @description
-//   Related lists used for content sidebars
+//   Related lists used for content sidebars.
 //
 // @markup
 //   <ul class="us-related us-list--reset">

--- a/vendor/assets/stylesheets/ustyle/basics/_typography.scss
+++ b/vendor/assets/stylesheets/ustyle/basics/_typography.scss
@@ -4,7 +4,7 @@
   //
   // @description
   //   The default heading styling across all uSwitch pages.
-  //   We allow extending the sizes of these headings with `%heading-{$i}` so that we don't repeat similar font sizes across the site
+  //   We allow extending the sizes of these headings with `%heading-{$i}` so that we don't repeat similar font sizes across the site.
   //
   // @markup
   //  <h1>Heading 1</h1>
@@ -48,7 +48,7 @@
   // @description
   //   Default paragraph styling with a margin bottom.
   //
-  // @state .us-standfirst - Used for heros and introductory paragraphs
+  // @state .us-standfirst - Used for heros and introductory paragraphs.
   //
   // @markup
   //   <p class="{$modifiers}">
@@ -70,7 +70,7 @@
   // @name Lists
   //
   // @description
-  //   Normal list styling
+  //   Normal list styling.
   //
   // @markup
   //   <ul>
@@ -93,7 +93,7 @@
   // @name Blockquote
   //
   // @description
-  //   Default blockquote
+  //   Default blockquote.
   //
   // @markup
   //   <blockquote>

--- a/vendor/assets/stylesheets/ustyle/components/_button.scss
+++ b/vendor/assets/stylesheets/ustyle/components/_button.scss
@@ -2,19 +2,19 @@
 // @name Buttons
 //
 // @description
-//   Our buttons used across the site. The states give different use cases. Both `<a>` and `<button>` tags are supported. Please use `role='button'` when using in a `<a>` tag.
+//   Our buttons used across the site. The states give different use cases. Both `<a>` and `<button>` tags are supported. Please use `role='button'` when using an `<a>` tag.
 //
-// @state .us-btn--primary - Used a save/update button
-// @state .us-btn--action - Navigational button
-// @state .us-btn--secondary - Secondary
-// @state .us-btn--hero - Navy outline used for buttons on hero banners
-// @state .us-btn--reversed - White outline for dark backgrounds
-// @state .us-btn--large - Larger button for heros
-// @state .us-btn--small - Smaller button for mobile tables
-// @state .us-btn--blocked - Full width button
-// @state .us-btn--link - link style button
-// @state .us-btn--stronger - Emphasis button
-// @state .us-btn--disabled - Disabled styling (can also be styled with :disabled)
+// @state .us-btn--primary - Used as a save/update button.
+// @state .us-btn--action - Navigational button.
+// @state .us-btn--secondary - Secondary.
+// @state .us-btn--hero - Navy outline used for buttons on hero banners.
+// @state .us-btn--reversed - White outline for dark backgrounds.
+// @state .us-btn--large - Larger button for heros.
+// @state .us-btn--small - Smaller button for mobile tables.
+// @state .us-btn--blocked - Full width button.
+// @state .us-btn--link - link style button.
+// @state .us-btn--stronger - Emphasis button.
+// @state .us-btn--disabled - Disabled styling (can also be styled with :disabled).
 //
 // @markup
 //  <a href="#" class="us-btn {$modifiers}" role="button">Link Button</a>

--- a/vendor/assets/stylesheets/ustyle/components/_cta.scss
+++ b/vendor/assets/stylesheets/ustyle/components/_cta.scss
@@ -2,7 +2,7 @@
 // @name CTAs
 //
 // @description
-//  Used within guide and news articles, these CTAs are intended to not interupt the content but to integrate in more subtle means.
+//  Used within guide and news articles, these CTAs (Calls to Action) are intended to not interupt the content but to integrate in more subtle means.
 //
 // @markup
 //  <section class="us-cta cta cta-column">

--- a/vendor/assets/stylesheets/ustyle/components/_featured.scss
+++ b/vendor/assets/stylesheets/ustyle/components/_featured.scss
@@ -2,8 +2,8 @@
 // @name Featured deal
 //
 // @description
-//   The `.us-featured` is mostly composed by smaller components, the components can be shuffled around inside of a grid to create the needed variants.
-//   This featured deal won't make any assumptions around the media queries, it's up to you, to deal with it. As you can see on the examples.
+//   The `.us-featured` is mostly composed of smaller components, the components can be shuffled around inside of a grid to create the needed variants.
+//   This featured deal won't make any assumptions around the media queries, it's up to you to deal with it.
 //
 // @markup
 //<div class="us-container">
@@ -22,7 +22,7 @@
 //     </div>
 //   </div>
 //   <div class="us-desktop--hidden us-padding-top us-col-xsm-4 us-mobile-block">
-//     <img class="us-img--full" src="http://uswitch-wp-cms-assets.s3-website-eu-west-1.amazonaws.com//www.uswitch.com/money/guides/wp-content/uploads/2014/11/DB2011AU01018_SMALL.jpg" width="200">
+//     <img class="us-img--full" src="http://uswitch-wp-cms-assets.s3-website-eu-west-1.amazonaws.com/money/guides/wp-content/uploads/2014/11/DB2011AU01018_SMALL.jpg" width="200">
 //   </div>
 //   <div class="us-col-xsm-7 us-col-lg-8 us-col-sm-5">
 //     <ul>
@@ -50,7 +50,7 @@
 //     </div>
 //   </div>
 //   <div class="us-col-xsm-3 us-col-lg-4 us-tablet--block">
-//     <img class="us-img--full us-desktop--block" src="http://uswitch-wp-cms-assets.s3-website-eu-west-1.amazonaws.com//www.uswitch.com/money/guides/wp-content/uploads/2014/11/DB2011AU01018_SMALL.jpg" width="200">
+//     <img class="us-img--full us-desktop--block" src="http://uswitch-wp-cms-assets.s3-website-eu-west-1.amazonaws.com/money/guides/wp-content/uploads/2014/11/DB2011AU01018_SMALL.jpg" width="200">
 //     <button class="margin-top margin-bottom us-btn us-btn--primary us-btn us-btn--blocked">See deal</button>
 //     <div class="us-icon--before us-icon--small--before us-icon--typegrey--before us-icon--clock--before us-align--center">
 //       <strong>3 days left</strong>

--- a/vendor/assets/stylesheets/ustyle/components/_links.scss
+++ b/vendor/assets/stylesheets/ustyle/components/_links.scss
@@ -1,11 +1,11 @@
 // @page Pattern Library/Components
 // @name Anchor links
-// 
-// @description 
-//   Anchor tag styling, with and without a border
 //
-// @state .us-link - Adds a border bottom to the link
-// @state .us-link--light - Changes the link colors to white for when links are placed on dark backgrounds
+// @description
+//   Anchor tag styling, with and without a border.
+//
+// @state .us-link - Adds a border bottom to the link.
+// @state .us-link--light - Changes the link colours to white for when links are placed on dark backgrounds.
 //
 // @markup
 //   <a href="#" class="{$modifiers}">Link</a>

--- a/vendor/assets/stylesheets/ustyle/components/_lists-li.scss
+++ b/vendor/assets/stylesheets/ustyle/components/_lists-li.scss
@@ -4,7 +4,7 @@
 // @description
 //   Our default numbered list styling.
 //
-// @state .us-custom-list-alt - allows us to use the lists on hero/blue backgrounds.
+// @state .us-custom-list-alt - Allows us to use the lists on hero/blue backgrounds.
 //
 // @markup
 //   <ul class='us-numbered-list {$modifiers}'>
@@ -62,7 +62,9 @@
 // @name Ticked list
 //
 // @description
-//   Our default ticked list styling. `.us-custom-list-alt` allows us to use the lists on hero/blue backgrounds.
+//   Our default ticked list styling.
+//
+// @state .us-custom-list-alt - Allows us to use the lists on hero/blue backgrounds.
 //
 // @markup
 //   <ul class='us-ticked-list'>

--- a/vendor/assets/stylesheets/ustyle/components/_lists.scss
+++ b/vendor/assets/stylesheets/ustyle/components/_lists.scss
@@ -1,6 +1,6 @@
 // @page Pattern Library/Components
 // @name Link lists
-// 
+//
 // @description
 //   The default list styling for lists that have anchors to take you to other pages.
 //

--- a/vendor/assets/stylesheets/ustyle/components/_tooltip.scss
+++ b/vendor/assets/stylesheets/ustyle/components/_tooltip.scss
@@ -2,7 +2,7 @@
 // @name Tooltip
 //
 // @description
-//  `.us-tooltip` can be applied to any parent, and by hovering it, it will toggle the visibility of `.us-tooltip__note`. Please note that on mobile viewports, the tooltip will appeat underneath the element that is aligned with the tooltip icon.
+//  `.us-tooltip` can be applied to any parent, and by hovering over it, it will toggle the visibility of `.us-tooltip__note`. Please note that on mobile viewports, the tooltip will appeat underneath the element that is aligned with the tooltip icon.
 //
 // @state .us-tooltip--top
 // @state .us-tooltip--bottom

--- a/vendor/assets/stylesheets/ustyle/components/_usp.scss
+++ b/vendor/assets/stylesheets/ustyle/components/_usp.scss
@@ -1,20 +1,20 @@
 // @page Pattern Library/Components
 // @name USPs
 //
-// @description 
+// @description
 // USPs (Unique Selling Points) are used within tables and on splash pages to highlight offers within a deal, and also to differentiate deals.
 // General guidelines; There should only be one USP per deal. Text within USPs should be written in sentence case (not uppercase).
 //
-// @state .us-usp--blue - uSwitch related
-// @state .us-usp--orange - Rewards (money/points)
-// @state .us-usp--purple - Gifts eg. free TV
-// @state .us-usp--yellow - Vouchers
-// @state .us-usp--typecyan - Micro persuasions eg. most popular, half price
-// @state .us-usp--green - Renewable and environmentally friendly
-// @state .us-usp--navy - Generic vertical specific USP
-// @state .us-usp--cyan - Generic vertical specific USP
-// @state .us-usp--typegrey - Generic vertical specific USP
-// @state .us-usp--red - Generic vertical specific USP
+// @state .us-usp--blue - uSwitch related.
+// @state .us-usp--orange - Rewards (money/points).
+// @state .us-usp--purple - Gifts eg. free TV.
+// @state .us-usp--yellow - Vouchers.
+// @state .us-usp--typecyan - Micro persuasions eg. most popular, half price.
+// @state .us-usp--green - Renewable and environmentally friendly.
+// @state .us-usp--navy - Generic vertical specific USP.
+// @state .us-usp--cyan - Generic vertical specific USP.
+// @state .us-usp--typegrey - Generic vertical specific USP.
+// @state .us-usp--red - Generic vertical specific USP.
 //
 // @markup
 //   <div class='us-usp {$modifiers}'>Shortened USP</div>

--- a/vendor/assets/stylesheets/ustyle/forms/_fields.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_fields.scss
@@ -7,8 +7,8 @@
 //   #### Best practices
 //   * For text inputs that are optional, add "(optional)" to the `placeholder` attribute for the input. Not highlighting required fields makes the form look less intimidating.
 //
-// @state .us-field--blocked - Blocked label styling
-// @state .us-field--inline - Inline label styling
+// @state .us-field--blocked - Blocked label styling.
+// @state .us-field--inline - Inline label styling.
 //
 // @markup
 //   <div class="us-field {$modifiers}">
@@ -63,7 +63,7 @@ $label-inline-breakpoint: tablet !default;
 }
 
 // The toggle field is for radios and checkboxes. It sits within the .us-field to allow
-// styling for labels of radio/checboxes
+// styling for labels of radio/checkboxes
 .us-field-toggle {
   label {
     @include normal-font;

--- a/vendor/assets/stylesheets/ustyle/forms/_input-group.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_input-group.scss
@@ -2,10 +2,10 @@
 // @name Input group
 //
 // @description
-//   Inputs groups allow you to add "boxes" to the left or right of an input. These boxes usually contain a visual icon to represent the usage of the input
+//   Input groups allow you to add "boxes" to the left or right of an input. These boxes usually contain a visual icon to represent the usage of the input.
 //
-// @state .us-input-group--disabled - Disabled state for input groups
-// @state .us-input-group--blocked - Fluid style
+// @state .us-input-group--disabled - Disabled state for input groups.
+// @state .us-input-group--blocked - Fluid style.
 //
 // @markup
 //   <div class="us-input-group us-margin-bottom {$modifiers}">

--- a/vendor/assets/stylesheets/ustyle/forms/_input.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_input.scss
@@ -8,11 +8,11 @@
 //   * Specifying an appropriate [type attribute](https://developer.mozilla.org/en/docs/Web/HTML/Element/Input#attr-type) (e.g. type="tel" for telephone number fields) will not only control what input is displayed, but also helps mobile devices select a keyboard layout suitable for entering that type of data.
 //   * Where appropriate use the [autocomplete attribute](https://developer.mozilla.org/en/docs/Web/HTML/Element/Input#attr-autocomplete) to make it easier for the browser to fill in fields on the users behalf, saving them time on lengthy forms.
 //
-// @state .us-form-input--large - Larger input style
-// @state .us-form-input--blocked - Fluid input style
-// @state .us-form-input--error - Visual feedback for when the input has an error
-// @state .us-form-input--success - Visual feedback for when success needs to be communicated to the user
-// @state .us-form-input--disabled - Inactive state for form inputs that can't be interacted with
+// @state .us-form-input--large - Larger input style.
+// @state .us-form-input--blocked - Fluid input style.
+// @state .us-form-input--error - Visual feedback for when the input has an error.
+// @state .us-form-input--success - Visual feedback for when success needs to be communicated to the user.
+// @state .us-form-input--disabled - Inactive state for form inputs that can't be interacted with.
 //
 // @markup
 //   <input class="us-form-input {$modifiers}" type="text" placeholder="Placeholder">

--- a/vendor/assets/stylesheets/ustyle/forms/_radio-checkbox.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_radio-checkbox.scss
@@ -12,7 +12,7 @@
 //   * Provide a default selection to radio and checkbox groups if it's necessary and wont be changed by 90% of your users.
 //   * Try to keep the number of radio buttons and checkboxes in the same group to a maximum of 6.
 //
-// @state us-form-input--disabled - Like other types of form inputs, adding this class to the element in conjunction with the disabled attribute helps to make the element look like it can't be interacted with
+// @state us-form-input--disabled - Like other types of form inputs, adding this class to the element in conjunction with the disabled attribute helps to make the element look like it can't be interacted with.
 //
 // @markup
 //   <div class="us-field us-field--blocked">

--- a/vendor/assets/stylesheets/ustyle/forms/_select.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_select.scss
@@ -2,16 +2,16 @@
 // @name Selects
 //
 // @description
-//   Select boxes allow users to choose and option or options from a list of options.
+//   Select boxes allow users to choose an option or options from a list of options.
 //
 //   #### Best practices
 //   * Use select boxes when choosing one or more options from a list of related, but mutually exclusive options e.g. profession, title, month.
 //   * It can be tempting to put many things in a select box for users to choose from. Try to keep the list of options to between 4 and 15 so the user doesn't become overwhelmed with choices.
 //
 // @state .us-form-select--multiple - Removes the drop down arrow and adjusts the padding of <option> elements. Useful when using <select> elements that have the size="" attribute set to anything higher than 1.
-// @state .us-form-select--blocked - Fluid style
-// @state .us-form-select--error - Visual feedback for when the input has an error
-// @state .us-form-select--success - Visual feedback for when success needs to be communicated to the user
+// @state .us-form-select--blocked - Fluid style.
+// @state .us-form-select--error - Visual feedback for when the input has an error.
+// @state .us-form-select--success - Visual feedback for when success needs to be communicated to the user.
 // @state .us-form-select--disabled - Inactive state for select boxes. You may also just add the disabled attribute to the <select> element in order to achieve the same effect.
 //
 // @markup

--- a/vendor/assets/stylesheets/ustyle/forms/_textarea.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_textarea.scss
@@ -5,8 +5,8 @@
 //   Our standard textarea styling across the website.
 //
 //
-// @state .us-form-textarea--blocked - Fluid textarea style
-// @state .us-form-textarea--disabled - Inactive state for textareas that can't be interacted with
+// @state .us-form-textarea--blocked - Fluid textarea style.
+// @state .us-form-textarea--disabled - Inactive state for textareas that can't be interacted with.
 //
 // @markup
 //   <textarea class="us-form-textarea {$modifiers}"></textarea>

--- a/vendor/assets/stylesheets/ustyle/forms/_toggle.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_toggle.scss
@@ -2,15 +2,15 @@
 // @name Toggle
 //
 // @description
-//  Toggle buttons provide and alternative way of displaying radio groups with a small number of options to a user.
+//  Toggle buttons provide an alternative way of displaying radio groups with a small number of options to a user.
 //  IE8 support is included with `radioToggle.js` which sets a `.checked` class on the radio button when clicked.
 //
 //  #### Best practices
-//  * Use as an alternation to radio groups that have short labels for each option (Yes/No, Opt-in/Opt-out).
+//  * Use as an alternative to radio groups that have short labels for each option (Yes/No, Opt-in/Opt-out).
 //  * For forms that have many short radio group questions in them, toggle buttons provide a better experience for quickly selecting answers on both desktop and mobile due to larger visible click areas for each option.
 //  * Limit the number of options in the toggle group to 3.
 //
-// @state .us-toggle__btn--disabled - Visual styling for toggle buttons that can't be interacted with
+// @state .us-toggle__btn--disabled - Visual styling for toggle buttons that can't be interacted with.
 //
 // @javascript
 //   var radioToggle = new RadioToggle({

--- a/vendor/assets/stylesheets/ustyle/forms/_validation.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_validation.scss
@@ -8,8 +8,8 @@
 //   * For inputs that have a label above them, place the validation message between the input and the label.
 //   * Use success validation messages only when it makes sense to contextually. For example, they can help to reassure users about the data they entered when multiple criteria need to be satisfied, e.g. password fields.
 //
-// @state .us-validation--error - Error styling for incorrect data on forms
-// @state .us-validation--success - Success styling for correct forms
+// @state .us-validation--error - Error styling for incorrect data on forms.
+// @state .us-validation--success - Success styling for correct forms.
 //
 // @markup
 //   <div class="us-field">

--- a/vendor/assets/stylesheets/ustyle/utilities/_general.scss
+++ b/vendor/assets/stylesheets/ustyle/utilities/_general.scss
@@ -4,15 +4,15 @@
 // @description
 //   These utility classes allow for some basic CSS properties to be applied across elements. The classname applies to the property that is getting set, with the value as the modifier.
 //
-// @state .us-clearfix - Clear floats
-// @state .us-float--left - Float element to the left
-// @state .us-float--right - Float element to the right
-// @state .us-align--left - Align content of the element to the left
-// @state .us-align--center - Align content of the element to the center
-// @state .us-align--right - Align content of the element to the right
-// @state .us-block - Display element as a block
-// @state .us-color--cyan - Change content color to blue, navy, typecyan, cyan, red, green
-// @state .us-list--reset - Reset list style
+// @state .us-clearfix - Clear floats.
+// @state .us-float--left - Float element to the left.
+// @state .us-float--right - Float element to the right.
+// @state .us-align--left - Align content of the element to the left.
+// @state .us-align--center - Align content of the element to the center.
+// @state .us-align--right - Align content of the element to the right.
+// @state .us-block - Display element as a block.
+// @state .us-color--cyan - Change content color to blue, navy, typecyan, cyan, red, green.
+// @state .us-list--reset - Reset list style.
 //
 // @markup
 //   <div class='{$modifiers}'>

--- a/vendor/assets/stylesheets/ustyle/utilities/_images.scss
+++ b/vendor/assets/stylesheets/ustyle/utilities/_images.scss
@@ -4,13 +4,13 @@
 // @description
 //   Helpful image classes for making images full width or floating within content.
 //
-// @state .us-img--full - Full width image
-// @state .us-img--left - Left floated image
-// @state .us-img--right - Right floated image
+// @state .us-img--full - Full width image.
+// @state .us-img--left - Left floated image.
+// @state .us-img--right - Right floated image.
 //
 // @markup
 //   <p>
-//     <img class="{$modifiers}" src="http://uswitch-wp-cms-assets.s3-website-eu-west-1.amazonaws.com//www.uswitch.com/money/guides/wp-content/uploads/2014/11/DB2011AU01018_SMALL.jpg" width="400">
+//     <img class="{$modifiers}" src="http://uswitch-wp-cms-assets.s3-website-eu-west-1.amazonaws.com/money/guides/wp-content/uploads/2014/11/DB2011AU01018_SMALL.jpg" width="400">
 //     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas mattis sit amet magna porta mollis. Pellentesque id pretium quam. Proin nec blandit ligula. Sed lectus orci, mattis ac hendrerit at, ultrices eget metus. Vestibulum dignissim venenatis malesuada. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent eget convallis urna, at ultrices ligula. Donec bibendum, lectus at consequat feugiat, nisi leo tincidunt purus, et condimentum lorem diam scelerisque neque. Nam imperdiet aliquet arcu a rhoncus.
 //   </p>
 

--- a/vendor/assets/stylesheets/ustyle/utilities/_spacing.scss
+++ b/vendor/assets/stylesheets/ustyle/utilities/_spacing.scss
@@ -2,37 +2,37 @@
 // @name Spacing
 //
 // @description
-//   Allow control of spacing around element. You can set margin or padding for an element without creating an extra class.
+//   Allow control of spacing around an element. You can set margin or padding for an element without creating an extra class.
 //   An example of this `.us-margin-top`, `.us-margin-top--small`, `.us-margin-top--large` where `margin` can be replaced by `padding` and `top` can be replaced by `bottom`, `left` or `right`.
 //   Default space for margin and padding is 1em, `small` modifier uses .5em and `large` modifier uses 1.5em.
 //
-// @state .us-margin-top - Use default top margin (1em)
-// @state .us-margin-top--small - Use small top margin (.5em)
-// @state .us-margin-top--large - Use large top margin (1.5em)
-// @state .us-margin-bottom - Use default bottom margin (1em)
-// @state .us-margin-bottom--small - Use small bottom margin (.5em)
-// @state .us-margin-bottom--large - Use large bottom margin (1.5em)
-// @state .us-margin-left - Use default left margin (1em)
-// @state .us-margin-left--small - Use small left margin (.5em)
-// @state .us-margin-left--large - Use large left margin (1.5em)
-// @state .us-margin-right - Use default right margin (1em)
-// @state .us-margin-right--small - Use small right margin (.5em)
-// @state .us-margin-right--large - Use large right margin (1.5em)
-// @state .us-padding-top - Use default top padding (1em)
-// @state .us-padding-top--small - Use small top padding (.5em)
-// @state .us-padding-top--large - Use large top padding (1.5em)
-// @state .us-padding-bottom - Use default bottom padding (1em)
-// @state .us-padding-bottom--small - Use small bottom padding (.5em)
-// @state .us-padding-bottom--large - Use large bottom padding (1.5em)
-// @state .us-padding-left - Use default left padding (1em)
-// @state .us-padding-left--small - Use small left padding (.5em)
-// @state .us-padding-left--large - Use large left padding (1.5em)
-// @state .us-padding-right - Use default right padding (1em)
-// @state .us-padding-right--small - Use small right padding (.5em)
-// @state .us-padding-right--large - Use large right padding (1.5em)
-// @state .us-reset--padding - Reset padding to 0
-// @state .us-reset--margin - Reset margin to 0
-// @state .us-reset - Reset padding and margin to 0
+// @state .us-margin-top - Use default top margin (1em).
+// @state .us-margin-top--small - Use small top margin (.5em).
+// @state .us-margin-top--large - Use large top margin (1.5em).
+// @state .us-margin-bottom - Use default bottom margin (1em).
+// @state .us-margin-bottom--small - Use small bottom margin (.5em).
+// @state .us-margin-bottom--large - Use large bottom margin (1.5em).
+// @state .us-margin-left - Use default left margin (1em).
+// @state .us-margin-left--small - Use small left margin (.5em).
+// @state .us-margin-left--large - Use large left margin (1.5em).
+// @state .us-margin-right - Use default right margin (1em).
+// @state .us-margin-right--small - Use small right margin (.5em).
+// @state .us-margin-right--large - Use large right margin (1.5em).
+// @state .us-padding-top - Use default top padding (1em).
+// @state .us-padding-top--small - Use small top padding (.5em).
+// @state .us-padding-top--large - Use large top padding (1.5em).
+// @state .us-padding-bottom - Use default bottom padding (1em).
+// @state .us-padding-bottom--small - Use small bottom padding (.5em).
+// @state .us-padding-bottom--large - Use large bottom padding (1.5em).
+// @state .us-padding-left - Use default left padding (1em).
+// @state .us-padding-left--small - Use small left padding (.5em).
+// @state .us-padding-left--large - Use large left padding (1.5em).
+// @state .us-padding-right - Use default right padding (1em).
+// @state .us-padding-right--small - Use small right padding (.5em).
+// @state .us-padding-right--large - Use large right padding (1.5em).
+// @state .us-reset--padding - Reset padding to 0.
+// @state .us-reset--margin - Reset margin to 0.
+// @state .us-reset - Reset padding and margin to 0.
 //
 // @markup
 //   <div class='class-goes-here {$modifiers}'>Sample content</div>


### PR DESCRIPTION
Sit down, grab a ☕️ and let's go through this!

This PR does three main things, for the 'Pattern Library' section of uStyle.

1. Brings consistent use of periods (.) across all pattern library documentation.
1. Fixes all apparent broken images across the pattern library documentation.
1. Fixes grammar and spelling.

I divided each section of the pattern library into separate commits, in the hope that it's a little bit easier to parse.

🌟 