### PR TITLE
Fix radio buttons and checkboxes in Firefox

### DIFF
--- a/vendor/assets/stylesheets/ustyle/forms/_radio-checkbox.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_radio-checkbox.scss
@@ -46,7 +46,7 @@
 //   </div>
 
 .us-form-input {
-  @include hidpi(0) {
+  @include hidpi(1) {
     &[type="checkbox"] {
       &:after {
         position: absolute;


### PR DESCRIPTION
The `hidpi()` mixin we use to style radio buttons and checkboxes for browsers that support styled form elements is broken in Firefox 54. A value of `0dppx` for `min-resolution` is no longer valid, so the media query's styles are never applied. Changing the argument from 0 to 1 fixes the problem and older browsers still maintain their default OS look for radio buttons and checkboxes.

Before:
<img width="319" alt="screen shot 2017-06-27 at 15 15 52" src="https://user-images.githubusercontent.com/286404/27592284-02b985ce-5b4c-11e7-99f8-60e2d48df7f1.png">

After:
<img width="312" alt="screen shot 2017-06-27 at 15 16 00" src="https://user-images.githubusercontent.com/286404/27592299-08093fec-5b4c-11e7-802a-6e79a14c521a.png">
