### PR TITLE
Radio Buttons/Checkboxes on low density devices

### DIFF
--- a/vendor/assets/stylesheets/ustyle/forms/_radio-checkbox.scss
+++ b/vendor/assets/stylesheets/ustyle/forms/_radio-checkbox.scss
@@ -46,7 +46,7 @@
 //   </div>
 
 .us-form-input {
-  @include hidpi(1) {
+  @include hidpi(0.1) {
     &[type="checkbox"] {
       &:after {
         position: absolute;


### PR DESCRIPTION
Looks like there are some displays that are reporting `window.devicePixelRatio` of less than one, meaning the fix that was implemented for Firefox no longer works on those devices.

`0.1` is a valid `<number>` value for `min-resolution` and `min-device-pixel-ratio` and things are now working again when I simulate a low density display.