### PR TITLE
Easier uStyle Sass in Node apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ This project is provided as is and is aimed at building uSwitch specific project
 * [Installation](#installation)
   * [Sinatra](#sinatra)
 * [Usage](#usage)
-  * [Mixins/Varibales](#mixins-variables)
+  * [Rails / Sprockets apps](#rails--sprockets-apps)
+  * [Node apps](#node-apps)
+  * [Mixins/Varibales](#mixins--variables)
 * [Development](#development)
 * [Contributing](#contributing)
 
@@ -113,7 +115,7 @@ You can then successfully reference your icon like so:
 
 ## Usage
 
-### Rails/Sprockets apps
+### Rails / Sprockets apps
 
 If using Rails and Sass, just import the base uSwitch styles at the start of your file
 

--- a/README.md
+++ b/README.md
@@ -113,13 +113,45 @@ You can then successfully reference your icon like so:
 
 ## Usage
 
-If using rails and SASS, just import the base uSwitch styles at the start of your file
+### Rails/Sprockets apps
+
+If using Rails and Sass, just import the base uSwitch styles at the start of your file
 
 ```scss
 @import "ustyle";
 ```
 
 This will import the main components. If you want more granular control of what to import, please look at the source code or the styleguide.
+
+### Node apps
+
+uStyle comes with JavaScript implementations of the custom Sass Ruby functions used by Sprockets. To use uStyle's mixins and variables within your own Sass, you'll need to add these functions to the compiler you're using. For example, using [node-sass](https://github.com/sass/node-sass) in a project that also has [Webpack](https://webpack.js.org/), you can do the following:
+
+```javascript
+// In your webpack.config.js
+
+import { SassHelpers } from 'ustyle';
+
+module.exports = {
+  // ...
+  module: {
+    rules: [
+      // ...
+      {
+        test: /.scss$/,
+        use: [{
+          loader: 'sass-loader',
+          options: {
+            functions: SassHelpers
+          }
+        }]
+      }
+      // ...
+    ]
+  }
+  // ...
+};
+```
 
 ### Mixins / Variables
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,31 @@
+const types = require('node-sass').types;
+const path = require('path');
+const fs = require('fs');
+
+const base64encode = string => {
+  const stringBuffer = Buffer.from(string.getValue());
+  return types.String(stringBuffer.toString('base64'));
+};
+
+const inlineSVG = source => {
+  const sourcePath = path.join(__dirname, 'vendor', 'assets', 'images', source.getValue());
+  let svg = '';
+
+  try {
+    svg = fs.readFileSync(sourcePath).toString();
+  } catch (err) {
+    console.error('Error inlining SVG file', err);
+  }
+
+  const dataUrl = `url('data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}')`;
+  return types.String(dataUrl);
+};
+
+const SassHelpers = {
+  'base64encode($string)': base64encode,
+  'inline-svg($source)': inlineSVG
+};
+
+module.exports = {
+  SassHelpers
+};

--- a/package.json
+++ b/package.json
@@ -27,10 +27,12 @@
     "Ivo Reis <ivo.reis@uswitch.com>",
     "Charlotte Spencer <charlotte.spencer@uswitch.com>"
   ],
-  "main": "dist/ustyle-latest.css",
+  "main": "index.js",
   "files": [
     "dist",
-    "vendor/assets/stylesheets"
+    "vendor/assets/stylesheets",
+    "vendor/assets/images/forms",
+    "index.js"
   ],
   "repository": "uswitch/ustyle",
   "scripts": {
@@ -67,6 +69,7 @@
     "load-grunt-tasks": "~3.1.0",
     "lodash": "^2.4.1",
     "marked": "^0.3.2",
+    "node-sass": "^4.5.3",
     "path": "^0.11.14",
     "semver": "^4.3.3",
     "simple-git": "^1.3.0",

--- a/vendor/assets/javascripts/ustyle/overlay.js
+++ b/vendor/assets/javascripts/ustyle/overlay.js
@@ -29,7 +29,7 @@ window.Overlay = (function(Utils) {
   }
 
   Overlay.prototype.addEventListeners = function() {
-    $(this.options.openButton).on("click.open-overlay", (function(_this) {
+    $(document.body).on("click.open-overlay", this.options.openButton, (function(_this) {
       return function(e) {
         if (_this.options.preventDefault) {
           e.preventDefault();


### PR DESCRIPTION
Compiling uStyle from source in Node apps currently requires your own JS implementations of the custom Ruby Sass functions we have in the project. This branch adds JS versions of those functions and corresponding SVG files so that you can use uStyle's variables and mixins in your own Sass.

TODO before merge:

- [x] Test locally in another Node project that's using uStyle from source
- [x] Add usage information to README