### PR TITLE
Include spinner.svg in distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dist",
     "vendor/assets/stylesheets",
     "vendor/assets/images/forms",
-    "vendor/assets/images/icons/spinner.svg",
+    "vendor/assets/images/icons",
     "index.js"
   ],
   "repository": "uswitch/ustyle",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dist",
     "vendor/assets/stylesheets",
     "vendor/assets/images/forms",
+    "vendor/assets/images/icons/spinner.svg",
     "index.js"
   ],
   "repository": "uswitch/ustyle",


### PR DESCRIPTION
spinner.svg and checkbox.svg are the only images that get inlined by the `inline-svg()` function, so both must be included in the npm package in order for custom builds of uStyle that make use of either image to work.