### PR TITLE
Adds secondary colours to us-color utility

### DIFF
--- a/vendor/assets/stylesheets/ustyle/utilities/_general.scss
+++ b/vendor/assets/stylesheets/ustyle/utilities/_general.scss
@@ -82,7 +82,13 @@ $colors: (
   "typegrey-2" $c-typegrey-2,
   "inputgrey" $c-inputgrey,
   "bordergrey" $c-bordergrey,
-  "keylinegrey" $c-keylinegrey
+  "keylinegrey" $c-keylinegrey,
+  "blue-light" $c-blue-light,
+  "typecyan-light" $c-typecyan-light,
+  "cyan-light" $c-cyan-light,
+  "yellow" $c-yellow,
+  "orange" $c-orange,
+  "purple" $c-purple
 );
 
 @each $color in $colors {


### PR DESCRIPTION
The reason for this is that sometimes we build content dynamically that relies on an api response containing the colour.