### PR TITLE
Remove double underline on links

### DIFF
--- a/vendor/assets/stylesheets/ustyle/components/_links.scss
+++ b/vendor/assets/stylesheets/ustyle/components/_links.scss
@@ -12,6 +12,7 @@
 
 %anchor-link {
   text-decoration: underline;
+  border-bottom: none;
 }
 
 a,


### PR DESCRIPTION
If both new and old (via includes) ustyle versions are required, a double underline currently appears on links.